### PR TITLE
Remove unneeded custom server from Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,29 +1,4 @@
-FROM mcr.microsoft.com/dotnet/aspnet:6.0 AS base
-WORKDIR /app
-
-ENV ASPNETCORE_URLS=http://+:80
-
-FROM mcr.microsoft.com/dotnet/sdk:6.0 AS build-dotnet
-WORKDIR /src
-
-COPY ["./PrincipleStudios.Tools.sln", "./"]
-COPY ["./PrincipleStudios.Tools.Server/PrincipleStudios.Tools.Server.csproj", "./PrincipleStudios.Tools.Server/"]
-# COPY ["./PrincipleStudios.Tools.Tests/PrincipleStudios.Tools.Tests.csproj", "./PrincipleStudios.Tools.Tests/"]
-RUN dotnet restore
-
-# COPY ./schemas/ ./schemas/
-COPY ./PrincipleStudios.Tools.Server/ ./PrincipleStudios.Tools.Server/
-# COPY ./PrincipleStudios.Tools.Tests/ ./PrincipleStudios.Tools.Tests/
-# COPY ./Directory.Build.props .
-# WORKDIR "/src/PrincipleStudios.Tools.Tests"
-# RUN dotnet build -p:SkipUiBuild=true
-# RUN dotnet test --no-build
-WORKDIR "/src/PrincipleStudios.Tools.Server"
-RUN dotnet build "PrincipleStudios.Tools.Server.csproj" -c Release -o /app/build
-
-FROM build-dotnet AS publish-dotnet
-RUN dotnet publish "PrincipleStudios.Tools.Server.csproj" -c Release -o /app/publish -p:SkipUiBuild=true
-
+FROM principlestudios.azurecr.io/dotnet-static-files-server AS base
 
 FROM node:16-alpine AS build-node
 # Check https://github.com/nodejs/docker-node/tree/b4117f9333da4138b03a546ec926ef50a31506c3#nodealpine to understand why libc6-compat might be needed.
@@ -46,10 +21,6 @@ ENV NEXT_PUBLIC_PR_ID=$PR_ID
 RUN npm run build
 
 FROM base AS final
-
-WORKDIR /app
-COPY --from=publish-dotnet /app/publish .
-ENTRYPOINT ["dotnet", "PrincipleStudios.Tools.Server.dll"]
 
 # ARG GITHASH
 # ENV BUILD__GITHASH=${GITHASH}


### PR DESCRIPTION
Leverages the shared static files server (which is on .NET 7) from our Azure ACR to accelerate build times.